### PR TITLE
Refactor explosion spawning

### DIFF
--- a/Enemy.py
+++ b/Enemy.py
@@ -1,5 +1,6 @@
 import pyxel
 import Common
+from ExplodeManager import ExpType
 
 class Enemy:
     def __init__(self, x, y, w=8, h=    8, life = 1, score=10):
@@ -37,10 +38,10 @@ class Enemy:
             self.active = False  # エネミーを非アクティブに
             Common.Score += self.Score  # スコア加算
             pyxel.play(0, 1)  # 効果音再生
-            Common.explode_manager.SpawnExplode_Rect(self.x + 4, self.y + 4, 20)
+            Common.explode_manager.spawn_explosion(self.x + 4, self.y + 4, 20, ExpType.RECT)
         else:
             self.flash = 6  # 点滅処理
-            Common.explode_manager.SpawnExplode_DotRefrect(self.x + 4, self.y + 8, 5)
+            Common.explode_manager.spawn_explosion(self.x + 4, self.y + 8, 5, ExpType.DOT_REFRECT)
 
             pyxel.play(0, 2)  # 効果音再生
 

--- a/ExplodeManager.py
+++ b/ExplodeManager.py
@@ -1,7 +1,14 @@
 import pyxel
 import random
-#from dataclasses import dataclass
-#from Common import ExpType
+from enum import Enum
+
+
+class ExpType(Enum):
+    """Explosion particle type."""
+    RECT = 0
+    DOT = 1
+    CIRCLE = 2
+    DOT_REFRECT = 3
 
 class Explde_CIRCLE:
     def __init__(self, x, y, r=10):
@@ -198,21 +205,17 @@ class ExpMan:
     def __init__(self):
         self.explosions = []
 
-    def SpawnExplode_Rect(self, x, y, cnt = 20):
-        for c in range(cnt):
-            self.explosions.append(Explode_RECT(x, y))
+    def spawn_explosion(self, x, y, cnt=20, exp_type=ExpType.CIRCLE):
+        """Spawn explosion particles of specified type."""
+        particle_cls = {
+            ExpType.RECT: Explode_RECT,
+            ExpType.DOT: Explode_DOT,
+            ExpType.CIRCLE: Explde_CIRCLE,
+            ExpType.DOT_REFRECT: Explode_DOT_REFRECT,
+        }.get(exp_type, Explde_CIRCLE)
 
-    def SpawnExplode_Dot(self, x, y, cnt = 20):
-        for c in range(cnt):
-            self.explosions.append(Explode_DOT(x, y))
-
-    def SpawnExplode_Circle(self, x, y, cnt =20):
-        for c in range(cnt):
-            self.explosions.append(Explde_CIRCLE(x, y))
-    
-    def SpawnExplode_DotRefrect(self, x, y, cnt = 5):
-        for c in range(cnt):
-            self.explosions.append(Explode_DOT_REFRECT(x, y))
+        for _ in range(cnt):
+            self.explosions.append(particle_cls(x, y))
 
     def update(self):
         for exp in self.explosions:

--- a/Player.py
+++ b/Player.py
@@ -1,6 +1,7 @@
 import pyxel
 import Common
 import math
+from ExplodeManager import ExpType
 
 from Bullet import Bullet
 
@@ -102,7 +103,7 @@ class Player:
                                         _enemy.x + _enemy.col_x, _enemy.y + _enemy.col_y, _enemy.col_w, _enemy.col_h):
 
                         #爆発エフェクト   
-                        Common.explode_manager.SpawnExplode_Circle(self.x + 4, self.y + 4, 20)
+                        Common.explode_manager.spawn_explosion(self.x + 4, self.y + 4, 20, ExpType.CIRCLE)
 
                         #一度接触すると3秒クールタイム
                         self.ExplodeCoolTimer = EXPLODE_TIMER

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import random
 
 import Common
 from Enemy import Enemy
+from ExplodeManager import ExpType
 
 from StarManager import StarManager
 from Player import Player
@@ -127,8 +128,7 @@ class App:
         #ばくはつだーーーーーーーーーーーーーーーーーーーー
         #爆発パーティクルのテストコード
         if pyxel.btn(pyxel.KEY_Z):
-            #Common.explode_manager.spawn_explosion(50,50)
-            Common.explode_manager.SpawnExplode_Circle(50,50,20)
+            Common.explode_manager.spawn_explosion(50, 50, 20, ExpType.CIRCLE)
             #self.Explode_mgr.spawn_explosion(50, 50)
             #print("Z Key Pressed")
         #ばくはつだーーーーーーーーーーーーーーーーーーーー


### PR DESCRIPTION
## Summary
- centralize explosion particle creation under `ExpMan.spawn_explosion`
- add `ExpType` enum to specify particle types
- update game objects to use the new interface

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842ca092fcc8332b6e84eced3e933ca