### PR TITLE
Add helper for enemy sprites

### DIFF
--- a/Common.py
+++ b/Common.py
@@ -133,3 +133,19 @@ SprList = {
 
 
 }
+
+# --------------------------------------------------
+# Enemy sprite helper
+# --------------------------------------------------
+MAX_ENEMY_NUM = 5
+MAX_ANIM_PAT = 4
+
+
+def get_enemy_sprite(enemy_num: int, anim_pat: int) -> SpIdx:
+    """Return ``SpIdx`` for given enemy number and animation pattern."""
+
+    enemy_num = max(1, min(enemy_num, MAX_ENEMY_NUM))
+    anim_pat = anim_pat % MAX_ANIM_PAT
+
+    key = f"ENEMY{enemy_num:02d}_{anim_pat}"
+    return SprList.get(key, SprList["NULL"])

--- a/Enemy.py
+++ b/Enemy.py
@@ -5,7 +5,7 @@ from ExplodeManager import ExpType
 ANIM_FRAME = 10
 
 class Enemy:
-    def __init__(self, x, y, w=8, h=8, life = 1, score=10):
+    def __init__(self, x, y, w=8, h=8, life=1, score=10, sprite_num=1):
         self.x = x
         self.y = y
         self.w = w  # Sprite Width
@@ -20,6 +20,9 @@ class Enemy:
         self.Score = score
 
         self.flash = 0
+
+        # Enemy sprite id (1-5)
+        self.sprite_num = sprite_num
 
         self.active = True
 
@@ -58,13 +61,19 @@ class Enemy:
         ANIM_FRAME = 10
         anim_pat = pyxel.frame_count // ANIM_FRAME % 4  # 0～3でぐるぐる（アニメ切り替え）
 
-        sprite_key = f"ENEMY01_{anim_pat}"  # → "ENEMY01_0"～"ENEMY01_3"
-        
-        pyxel.blt(self.x, self.y, Common.TILE_BANK0, 
-                  Common.SprList[sprite_key].x, Common.SprList[sprite_key].y,
-                  #Common.SprList["ENEMY01_0"].x, Common.SprList["ENEMY01_0"].y,
-                  #Common.SprList["ENEMY05_0"].x, Common.SprList["ENEMY05_0"].y,
-                  self.w, self.h, pyxel.COLOR_BLACK)
+        # get sprite coordinates from Common by enemy number
+        sprite_idx = Common.get_enemy_sprite(self.sprite_num, anim_pat)
+
+        pyxel.blt(
+            self.x,
+            self.y,
+            Common.TILE_BANK0,
+            sprite_idx.x,
+            sprite_idx.y,
+            self.w,
+            self.h,
+            pyxel.COLOR_BLACK,
+        )
 
         pyxel.pal()
 

--- a/main.py
+++ b/main.py
@@ -54,7 +54,8 @@ def update_playing(self):
         for _x in range(10):
             enemy_x = OFSX + (BASEX * _x)
             enemy_y = 16
-            _Enemy = Enemy(enemy_x, enemy_y, 8, 8, 4, 100)
+            sprite_num = random.randint(1, Common.MAX_ENEMY_NUM)
+            _Enemy = Enemy(enemy_x, enemy_y, 8, 8, 4, 100, sprite_num)
             Common.enemy_list.append(_Enemy)
         
         Common.GameStateSub = Common.STATE_PLAYING_FIGHT


### PR DESCRIPTION
## Summary
- introduce `get_enemy_sprite` in `Common.py` and constants
- store enemy type in `Enemy` and use helper when drawing
- spawn enemies with random sprite numbers in the main loop

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68442502b66c8332ac1df247158b354c