### PR TITLE
Add group-based enemy movement

### DIFF
--- a/Common.py
+++ b/Common.py
@@ -51,6 +51,14 @@ GameTimer = 0
 HighScore = 0
 Score = 0
 
+# --------------------------------------------------
+# Enemy movement parameters
+# --------------------------------------------------
+# Horizontal speed of the enemy group
+ENEMY_MOVE_SPEED = 0.5
+# Current horizontal direction: 1 for right, -1 for left
+ENEMY_MOVE_DIR = 1
+
 
 
 

--- a/Enemy.py
+++ b/Enemy.py
@@ -26,10 +26,15 @@ class Enemy:
 
         self.active = True
 
+        # Movement parameters are handled globally
+
     def update(self):
-        
+
         if Common.StopTimer > 0:
-            return  
+            return
+
+        # Individual enemies no longer handle movement here.
+        # Movement is controlled at the formation level.
 
     def on_hit(self, bullet):
         # 弾を消す

--- a/main.py
+++ b/main.py
@@ -69,9 +69,19 @@ def update_playing(self):
             Common.GameStateSub = Common.STATE_PLAYING_ENEMY_SPAWN
         return
 
-    # --- 敵の移動処理だけを行う（衝突判定は外す） ---
-    for _e in Common.enemy_list:
-        _e.update()
+    # --- 敵の移動処理（グループで水平移動） ---
+    if Common.enemy_list:
+        left_edge = min(e.x for e in Common.enemy_list)
+        right_edge = max(e.x + e.w for e in Common.enemy_list)
+
+        if Common.ENEMY_MOVE_DIR < 0 and left_edge <= 0:
+            Common.ENEMY_MOVE_DIR = 1
+        elif Common.ENEMY_MOVE_DIR > 0 and right_edge >= Common.WIN_WIDTH:
+            Common.ENEMY_MOVE_DIR = -1
+
+        for _e in Common.enemy_list:
+            _e.x += Common.ENEMY_MOVE_SPEED * Common.ENEMY_MOVE_DIR
+            _e.update()
 
     # --- 衝突判定：プレイヤー弾 vs 敵 ---
     for bullet in Common.player_bullet_list:


### PR DESCRIPTION
## Summary
- move enemy formation left and right together
- track movement direction in `Common`

## Testing
- `python -m py_compile Enemy.py Common.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_684d611ed62c8332af2498667fbb1a26